### PR TITLE
Add before/after tables and when-to-use guidance to pivot chapter

### DIFF
--- a/_book/pivot_functions_extended.html
+++ b/_book/pivot_functions_extended.html
@@ -353,8 +353,16 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </nav>
 <div id="quarto-sidebar-glass" class="quarto-sidebar-collapse-item" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item"></div>
 <!-- margin-sidebar -->
-    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar zindex-bottom">
-        
+    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+        <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">Table of contents</h2>
+   
+  <ul>
+  <li><a href="#wide-vs-long-format" id="toc-wide-vs-long-format" class="nav-link active" data-scroll-target="#wide-vs-long-format"><span class="header-section-number">14.1</span> Wide vs long format</a></li>
+  <li><a href="#pivot_longer" id="toc-pivot_longer" class="nav-link" data-scroll-target="#pivot_longer"><span class="header-section-number">14.2</span> <code>pivot_longer()</code></a></li>
+  <li><a href="#pivot_wider" id="toc-pivot_wider" class="nav-link" data-scroll-target="#pivot_wider"><span class="header-section-number">14.3</span> <code>pivot_wider()</code></a></li>
+  </ul>
+<div class="toc-actions"><ul><li><a href="https://github.com/jarekbryk/huddr/edit/main/pivot_functions_extended.qmd" class="toc-action"><i class="bi bi-github"></i>Edit this page</a></li><li><a href="https://github.com/jarekbryk/huddr/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
 <!-- main -->
 <main class="content" id="quarto-document-content">
@@ -380,9 +388,85 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 
 <p>The pivot functions allow you to reshape your data sets, which is useful when preparing your data for analysis or visualization.</p>
 <ul>
-<li><code>pivot_longer()</code> - Allows you to lengthen your data set from a wide format to a long format by reducing the number of columns and increasing the number of rows.</li>
-<li><code>pivot_wider()</code> - Allows you to widen your data set from a long format to a wide format by reducing the number of rows and increasing the number of columns.</li>
+<li><code>pivot_longer()</code> - Converts <strong>wide</strong> data to <strong>long</strong> format: fewer columns, more rows.</li>
+<li><code>pivot_wider()</code> - Converts <strong>long</strong> data to <strong>wide</strong> format: more columns, fewer rows.</li>
 </ul>
+<section id="wide-vs-long-format" class="level2" data-number="14.1">
+<h2 data-number="14.1" class="anchored" data-anchor-id="wide-vs-long-format"><span class="header-section-number">14.1</span> Wide vs long format</h2>
+<p>It helps to see what these words mean before looking at code. Imagine a small table recording hindfoot length and weight for two animals:</p>
+<p><strong>Wide format</strong> (one row per animal, measurements spread across columns):</p>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>species_id</th>
+<th>hindfoot_length</th>
+<th>weight</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>NL</td>
+<td>32</td>
+<td>165</td>
+</tr>
+<tr class="even">
+<td>DM</td>
+<td>36</td>
+<td>43</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Long format</strong> (one row per measurement, a column for the measurement name and a column for the value):</p>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>species_id</th>
+<th>type_measurement</th>
+<th>measurements</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>NL</td>
+<td>hindfoot_length</td>
+<td>32</td>
+</tr>
+<tr class="even">
+<td>NL</td>
+<td>weight</td>
+<td>165</td>
+</tr>
+<tr class="odd">
+<td>DM</td>
+<td>hindfoot_length</td>
+<td>36</td>
+</tr>
+<tr class="even">
+<td>DM</td>
+<td>weight</td>
+<td>43</td>
+</tr>
+</tbody>
+</table>
+<div class="callout callout-style-default callout-note callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Note</span>When to use each
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<ul>
+<li>Use <strong><code>pivot_longer()</code></strong> (wide → long) when you want to plot or summarise multiple measurements together — for example, drawing a boxplot of several numeric columns at once with <code>ggplot2</code>.</li>
+<li>Use <strong><code>pivot_wider()</code></strong> (long → wide) when you need one column per group for comparison — for example, to create a summary table where each species gets its own column.</li>
+</ul>
+</div>
+</div>
+</section>
+<section id="pivot_longer" class="level2" data-number="14.2">
+<h2 data-number="14.2" class="anchored" data-anchor-id="pivot_longer"><span class="header-section-number">14.2</span> <code>pivot_longer()</code></h2>
 <div class="callout callout-style-default callout-tip callout-titled">
 <div class="callout-header d-flex align-content-center">
 <div class="callout-icon-container">
@@ -393,23 +477,47 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>pivot_function(data set name, cols = (column name : column name), names_to = “name”, values_to = “value”)</p>
+<p>pivot_longer(data, cols = first_col:last_col, names_to = “new_name_column”, values_to = “new_value_column”)</p>
 </div>
 </div>
 <ul>
-<li><code>cols</code> - The columns you want to pivot.</li>
-<li><code>names_to</code> - The new column name where you want all the variable names to go.</li>
-<li><code>values_to</code> - The new column name where you want all the values to go.</li>
+<li><code>cols</code> - The columns you want to pivot (use an unquoted range like <code>hindfoot_length:weight</code>).</li>
+<li><code>names_to</code> - The name of the new column that will hold the old column names.</li>
+<li><code>values_to</code> - The name of the new column that will hold the values.</li>
 </ul>
-<p>Here you can see an example of how you can use the <code>pivot_longer()</code> function in a data set:</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">pivot_longer</span>(rodents, <span class="at">cols =</span> hindfoot_length<span class="sc">:</span>weight, <span class="at">names_to =</span> <span class="st">"type_measurement"</span>, <span class="at">values_to =</span> <span class="st">"measurements"</span>)</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>rodents <span class="sc">|&gt;</span></span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">pivot_longer</span>(<span class="at">cols =</span> hindfoot_length<span class="sc">:</span>weight, <span class="at">names_to =</span> <span class="st">"type_measurement"</span>, <span class="at">values_to =</span> <span class="st">"measurements"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>rodents <span class="sc">|&gt;</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">pivot_longer</span>(<span class="at">cols =</span> hindfoot_length<span class="sc">:</span>weight, <span class="at">names_to =</span> <span class="st">"type_measurement"</span>, <span class="at">values_to =</span> <span class="st">"measurements"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</div>
+</section>
+<section id="pivot_wider" class="level2" data-number="14.3">
+<h2 data-number="14.3" class="anchored" data-anchor-id="pivot_wider"><span class="header-section-number">14.3</span> <code>pivot_wider()</code></h2>
+<div class="callout callout-style-default callout-tip callout-titled">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-title-container flex-fill">
+<span class="screen-reader-only">Tip</span>You do this by writing:
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>pivot_wider(data, names_from = column_with_names, values_from = column_with_values)</p>
+</div>
+</div>
+<ul>
+<li><code>names_from</code> - The column whose values will become the new column names.</li>
+<li><code>values_from</code> - The column whose values will fill those new columns.</li>
+</ul>
+<div class="cell">
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb2"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Example: count captures per species per year, then spread years into columns</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>rodents <span class="sc">|&gt;</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">count</span>(species_id, year) <span class="sc">|&gt;</span></span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">pivot_wider</span>(<span class="at">names_from =</span> year, <span class="at">values_from =</span> n)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 
 
+</section>
 
 </main> <!-- /main -->
 <script>
@@ -1035,4 +1143,4 @@ window.onload = function() {
 
 
 
-<footer class="footer"><div class="nav-footer"><div class="nav-footer-center"><div class="toc-actions"><ul><li><a href="https://github.com/jarekbryk/huddr/edit/main/pivot_functions_extended.qmd" class="toc-action"><i class="bi bi-github"></i>Edit this page</a></li><li><a href="https://github.com/jarekbryk/huddr/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div></div></footer></body></html>
+<footer class="footer"><div class="nav-footer"><div class="nav-footer-center"><div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/jarekbryk/huddr/edit/main/pivot_functions_extended.qmd" class="toc-action"><i class="bi bi-github"></i>Edit this page</a></li><li><a href="https://github.com/jarekbryk/huddr/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div></div></footer></body></html>

--- a/_book/practice_questions.html
+++ b/_book/practice_questions.html
@@ -406,8 +406,8 @@ Note
 <li></li>
 </ol>
 What are the steps to follow every time you start a new quatro doc?
-<div id="radio_LNCFANUIWE" class="webex-radiogroup">
-<label><input type="radio" autocomplete="off" name="radio_LNCFANUIWE" value="answer"> <span>A</span></label><label><input type="radio" autocomplete="off" name="radio_LNCFANUIWE" value=""> <span>B</span></label><label><input type="radio" autocomplete="off" name="radio_LNCFANUIWE" value=""> <span>C</span></label><label><input type="radio" autocomplete="off" name="radio_LNCFANUIWE" value=""> <span>D</span></label>
+<div id="radio_QFEOGBDBYJ" class="webex-radiogroup">
+<label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value="answer"> <span>A</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>B</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>C</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>D</span></label>
 </div>
 <ol type="A">
 <li><p>Open Quarto and create a new document. Load in the necessary libraries. Load the dataset. Make sure progress is saved to OneDrive or on your computer.</p></li>
@@ -421,8 +421,8 @@ What are the steps to follow every time you start a new quatro doc?
 <div class="webex-check webex-box">
 <p>filter can be used to group rows: <select class="webex-select"><option value="blank"></option><option value="answer">TRUE</option><option value="">FALSE</option></select></p>
 Which is the correct form?
-<div id="radio_LHMPCOCELT" class="webex-radiogroup">
-<label><input type="radio" autocomplete="off" name="radio_LHMPCOCELT" value=""> <span>filter(species_id = 'GM')</span></label><label><input type="radio" autocomplete="off" name="radio_LHMPCOCELT" value="answer"> <span>filter(species_id %in% c(DM, NL)</span></label><label><input type="radio" autocomplete="off" name="radio_LHMPCOCELT" value=""> <span>filter(species_id == %in% c(DM, NL)</span></label>
+<div id="radio_DGCPVOJOBB" class="webex-radiogroup">
+<label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value=""> <span>filter(species_id = 'GM')</span></label><label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value="answer"> <span>filter(species_id %in% c(DM, NL)</span></label><label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value=""> <span>filter(species_id == %in% c(DM, NL)</span></label>
 </div>
 </div>
 <ol start="2" type="1">

--- a/_book/search.json
+++ b/_book/search.json
@@ -543,7 +543,40 @@
     "href": "pivot_functions_extended.html",
     "title": "14  Even more about pivot functions",
     "section": "",
-    "text": "The pivot functions allow you to reshape your data sets, which is useful when preparing your data for analysis or visualization.\n\npivot_longer() - Allows you to lengthen your data set from a wide format to a long format by reducing the number of columns and increasing the number of rows.\npivot_wider() - Allows you to widen your data set from a long format to a wide format by reducing the number of rows and increasing the number of columns.\n\n\n\n\n\n\n\nTipYou do this by writing:\n\n\n\npivot_function(data set name, cols = (column name : column name), names_to = “name”, values_to = “value”)\n\n\n\ncols - The columns you want to pivot.\nnames_to - The new column name where you want all the variable names to go.\nvalues_to - The new column name where you want all the values to go.\n\nHere you can see an example of how you can use the pivot_longer() function in a data set:\n\npivot_longer(rodents, cols = hindfoot_length:weight, names_to = \"type_measurement\", values_to = \"measurements\")\n\nrodents |&gt;\n  pivot_longer(cols = hindfoot_length:weight, names_to = \"type_measurement\", values_to = \"measurements\")",
+    "text": "14.1 Wide vs long format\nThe pivot functions allow you to reshape your data sets, which is useful when preparing your data for analysis or visualization.\nIt helps to see what these words mean before looking at code. Imagine a small table recording hindfoot length and weight for two animals:\nWide format (one row per animal, measurements spread across columns):\nLong format (one row per measurement, a column for the measurement name and a column for the value):",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>14</span>  <span class='chapter-title'>Even more about pivot functions</span>"
+    ]
+  },
+  {
+    "objectID": "pivot_functions_extended.html#wide-vs-long-format",
+    "href": "pivot_functions_extended.html#wide-vs-long-format",
+    "title": "14  Even more about pivot functions",
+    "section": "",
+    "text": "species_id\nhindfoot_length\nweight\n\n\n\n\nNL\n32\n165\n\n\nDM\n36\n43\n\n\n\n\n\n\n\nspecies_id\ntype_measurement\nmeasurements\n\n\n\n\nNL\nhindfoot_length\n32\n\n\nNL\nweight\n165\n\n\nDM\nhindfoot_length\n36\n\n\nDM\nweight\n43\n\n\n\n\n\n\n\n\n\nNoteWhen to use each\n\n\n\n\nUse pivot_longer() (wide → long) when you want to plot or summarise multiple measurements together — for example, drawing a boxplot of several numeric columns at once with ggplot2.\nUse pivot_wider() (long → wide) when you need one column per group for comparison — for example, to create a summary table where each species gets its own column.",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>14</span>  <span class='chapter-title'>Even more about pivot functions</span>"
+    ]
+  },
+  {
+    "objectID": "pivot_functions_extended.html#pivot_longer",
+    "href": "pivot_functions_extended.html#pivot_longer",
+    "title": "14  Even more about pivot functions",
+    "section": "14.2 pivot_longer()",
+    "text": "14.2 pivot_longer()\n\n\n\n\n\n\nTipYou do this by writing:\n\n\n\npivot_longer(data, cols = first_col:last_col, names_to = “new_name_column”, values_to = “new_value_column”)\n\n\n\ncols - The columns you want to pivot (use an unquoted range like hindfoot_length:weight).\nnames_to - The name of the new column that will hold the old column names.\nvalues_to - The name of the new column that will hold the values.\n\n\nrodents |&gt;\n  pivot_longer(cols = hindfoot_length:weight, names_to = \"type_measurement\", values_to = \"measurements\")",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>14</span>  <span class='chapter-title'>Even more about pivot functions</span>"
+    ]
+  },
+  {
+    "objectID": "pivot_functions_extended.html#pivot_wider",
+    "href": "pivot_functions_extended.html#pivot_wider",
+    "title": "14  Even more about pivot functions",
+    "section": "14.3 pivot_wider()",
+    "text": "14.3 pivot_wider()\n\n\n\n\n\n\nTipYou do this by writing:\n\n\n\npivot_wider(data, names_from = column_with_names, values_from = column_with_values)\n\n\n\nnames_from - The column whose values will become the new column names.\nvalues_from - The column whose values will fill those new columns.\n\n\n# Example: count captures per species per year, then spread years into columns\nrodents |&gt;\n  count(species_id, year) |&gt;\n  pivot_wider(names_from = year, values_from = n)",
     "crumbs": [
       "Part 3: R fundamentals",
       "<span class='chapter-number'>14</span>  <span class='chapter-title'>Even more about pivot functions</span>"

--- a/pivot_functions_extended.qmd
+++ b/pivot_functions_extended.qmd
@@ -2,25 +2,69 @@
 
 The pivot functions allow you to reshape your data sets, which is useful when preparing your data for analysis or visualization.
 
--   `pivot_longer()` - Allows you to lengthen your data set from a wide format to a long format by reducing the number of columns and increasing the number of rows.
--   `pivot_wider()` - Allows you to widen your data set from a long format to a wide format by reducing the number of rows and increasing the number of columns.
+-   `pivot_longer()` - Converts **wide** data to **long** format: fewer columns, more rows.
+-   `pivot_wider()` - Converts **long** data to **wide** format: more columns, fewer rows.
+
+## Wide vs long format
+
+It helps to see what these words mean before looking at code. Imagine a small table recording hindfoot length and weight for two animals:
+
+**Wide format** (one row per animal, measurements spread across columns):
+
+| species_id | hindfoot_length | weight |
+|------------|-----------------|--------|
+| NL         | 32              | 165    |
+| DM         | 36              | 43     |
+
+**Long format** (one row per measurement, a column for the measurement name and a column for the value):
+
+| species_id | type_measurement | measurements |
+|------------|------------------|--------------|
+| NL         | hindfoot_length  | 32           |
+| NL         | weight           | 165          |
+| DM         | hindfoot_length  | 36           |
+| DM         | weight           | 43           |
+
+::: callout-note
+## When to use each
+
+-   Use **`pivot_longer()`** (wide → long) when you want to plot or summarise multiple measurements together — for example, drawing a boxplot of several numeric columns at once with `ggplot2`.
+-   Use **`pivot_wider()`** (long → wide) when you need one column per group for comparison — for example, to create a summary table where each species gets its own column.
+:::
+
+## `pivot_longer()`
 
 ::: callout-tip
 ## You do this by writing:
 
-pivot_function(data set name, cols = (column name : column name), names_to = "name", values_to = "value")
+pivot_longer(data, cols = first_col:last_col, names_to = "new_name_column", values_to = "new_value_column")
 :::
 
--   `cols` - The columns you want to pivot.
--   `names_to` - The new column name where you want all the variable names to go.
--   `values_to` - The new column name where you want all the values to go.
-
-Here you can see an example of how you can use the `pivot_longer()` function in a data set:
+-   `cols` - The columns you want to pivot (use an unquoted range like `hindfoot_length:weight`).
+-   `names_to` - The name of the new column that will hold the old column names.
+-   `values_to` - The name of the new column that will hold the values.
 
 ```{r}
 #| eval: false
-pivot_longer(rodents, cols = hindfoot_length:weight, names_to = "type_measurement", values_to = "measurements")
-
 rodents |>
   pivot_longer(cols = hindfoot_length:weight, names_to = "type_measurement", values_to = "measurements")
+```
+
+## `pivot_wider()`
+
+::: callout-tip
+## You do this by writing:
+
+pivot_wider(data, names_from = column_with_names, values_from = column_with_values)
+:::
+
+-   `names_from` - The column whose values will become the new column names.
+-   `values_from` - The column whose values will fill those new columns.
+
+```{r}
+#| eval: false
+# Example: count captures per species per year, then spread years into columns
+rodents |>
+  count(species_id, year) |>
+  pivot_wider(names_from = year, values_from = n)
 ```


### PR DESCRIPTION
- Add wide vs long format tables showing the transformation visually
- Add callout explaining when to reach for each function
- Restructure into labelled pivot_longer / pivot_wider sections
- Add pivot_wider() example (was missing entirely) Closes #21, #40, #59, #64, #69, #71.