### PR TITLE
Add join comparison table, concrete before/after outputs, key guidance

### DIFF
--- a/_book/joining_functions_extended.html
+++ b/_book/joining_functions_extended.html
@@ -358,7 +358,9 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <h2 id="toc-title">Table of contents</h2>
    
   <ul>
-  <li><a href="#useful-functions-and-parameters" id="toc-useful-functions-and-parameters" class="nav-link active" data-scroll-target="#useful-functions-and-parameters"><span class="header-section-number">13.0.1</span> Useful functions and parameters</a></li>
+  <li><a href="#the-four-join-types" id="toc-the-four-join-types" class="nav-link active" data-scroll-target="#the-four-join-types"><span class="header-section-number">13.1</span> The four join types</a></li>
+  <li><a href="#seeing-joins-in-action" id="toc-seeing-joins-in-action" class="nav-link" data-scroll-target="#seeing-joins-in-action"><span class="header-section-number">13.2</span> Seeing joins in action</a></li>
+  <li><a href="#joining-on-columns-with-different-names" id="toc-joining-on-columns-with-different-names" class="nav-link" data-scroll-target="#joining-on-columns-with-different-names"><span class="header-section-number">13.3</span> Joining on columns with different names</a></li>
   </ul>
 <div class="toc-actions"><ul><li><a href="https://github.com/jarekbryk/huddr/edit/main/joining_functions_extended.qmd" class="toc-action"><i class="bi bi-github"></i>Edit this page</a></li><li><a href="https://github.com/jarekbryk/huddr/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
@@ -384,21 +386,135 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </header>
 
 
-<p>The joining functions allow you to merge separate data sets based on matching keys.</p>
-<ul>
-<li><code>left_join()</code> - Keeps all the values from the left table and matching rows from the right table. All unmatched rows in the right table will be NA.</li>
-<li><code>right_join()</code> - Keeps all the values from the right table and matching rows from the left table. All unmatched rows in the left table will be NA.</li>
-<li><code>inner_join()</code> - Keeps all values that have matching keys in both tables.</li>
-<li><code>full_join()</code> - Keeps all values from both tables and all unmatched rows will be NA.</li>
-</ul>
-<section id="useful-functions-and-parameters" class="level3" data-number="13.0.1">
-<h3 data-number="13.0.1" class="anchored" data-anchor-id="useful-functions-and-parameters"><span class="header-section-number">13.0.1</span> Useful functions and parameters</h3>
-<blockquote class="blockquote">
-<ul>
-<li><code>by</code> - Specifies the key column/s to join on.</li>
-<li><code>c()</code> - Allows you to combine different joining keys if they don’t have the same name.</li>
-</ul>
-</blockquote>
+<p>The joining functions allow you to merge separate data sets based on a shared <strong>key</strong> column — a column that appears in both tables and contains matching values, such as a species ID or a sample name.</p>
+<section id="the-four-join-types" class="level2" data-number="13.1">
+<h2 data-number="13.1" class="anchored" data-anchor-id="the-four-join-types"><span class="header-section-number">13.1</span> The four join types</h2>
+<table class="caption-top table">
+<colgroup>
+<col style="width: 33%">
+<col style="width: 33%">
+<col style="width: 33%">
+</colgroup>
+<thead>
+<tr class="header">
+<th>Function</th>
+<th>Rows kept</th>
+<th>Use when…</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>left_join()</code></td>
+<td>All rows from the <strong>left</strong> table; matching rows from the right</td>
+<td>You want to keep all your primary data and add extra columns where available</td>
+</tr>
+<tr class="even">
+<td><code>right_join()</code></td>
+<td>All rows from the <strong>right</strong> table; matching rows from the left</td>
+<td>Same idea, but your primary data is on the right</td>
+</tr>
+<tr class="odd">
+<td><code>inner_join()</code></td>
+<td>Only rows with a matching key <strong>in both</strong> tables</td>
+<td>You only want rows that exist in both data sets</td>
+</tr>
+<tr class="even">
+<td><code>full_join()</code></td>
+<td>All rows from <strong>both</strong> tables</td>
+<td>You want to keep everything and fill gaps with <code>NA</code></td>
+</tr>
+</tbody>
+</table>
+<p>Rows with no match in the other table get <code>NA</code> in the columns that came from that table.</p>
+</section>
+<section id="seeing-joins-in-action" class="level2" data-number="13.2">
+<h2 data-number="13.2" class="anchored" data-anchor-id="seeing-joins-in-action"><span class="header-section-number">13.2</span> Seeing joins in action</h2>
+<p>The examples below use two small built-in dplyr data sets. Here is what they contain:</p>
+<div class="cell">
+<div class="cell-output cell-output-stderr">
+<pre><code>-- Attaching core tidyverse packages ------------------------ tidyverse 2.0.0 --
+v dplyr     1.2.1     v readr     2.2.0
+v forcats   1.0.1     v stringr   1.6.0
+v ggplot2   4.0.3     v tibble    3.3.1
+v lubridate 1.9.5     v tidyr     1.3.2
+v purrr     1.2.2     
+-- Conflicts ------------------------------------------ tidyverse_conflicts() --
+x dplyr::filter() masks stats::filter()
+x dplyr::lag()    masks stats::lag()
+i Use the conflicted package (&lt;http://conflicted.r-lib.org/&gt;) to force all conflicts to become errors</code></pre>
+</div>
+</div>
+<div class="cell">
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb2"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>band_members      <span class="co"># name + band</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 3 x 2
+  name  band   
+  &lt;chr&gt; &lt;chr&gt;  
+1 Mick  Stones 
+2 John  Beatles
+3 Paul  Beatles</code></pre>
+</div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb4"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>band_instruments  <span class="co"># name + plays</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 3 x 2
+  name  plays 
+  &lt;chr&gt; &lt;chr&gt; 
+1 John  guitar
+2 Paul  bass  
+3 Keith guitar</code></pre>
+</div>
+</div>
+<p><code>Mick</code> is in <code>band_members</code> but not in <code>band_instruments</code>. <code>Keith</code> is in <code>band_instruments</code> but not in <code>band_members</code>. The key column is <code>name</code>.</p>
+<div class="cell">
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb6"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co"># inner_join: only Mick and John appear in both tables — only they are kept</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="fu">inner_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 2 x 3
+  name  band    plays 
+  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; 
+1 John  Beatles guitar
+2 Paul  Beatles bass  </code></pre>
+</div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb8"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co"># left_join: all of band_members is kept; Keith (right only) is dropped</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="fu">left_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 3 x 3
+  name  band    plays 
+  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; 
+1 Mick  Stones  &lt;NA&gt;  
+2 John  Beatles guitar
+3 Paul  Beatles bass  </code></pre>
+</div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb10"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="co"># right_join: all of band_instruments is kept; Mick (left only) is dropped</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="fu">right_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 3 x 3
+  name  band    plays 
+  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; 
+1 John  Beatles guitar
+2 Paul  Beatles bass  
+3 Keith &lt;NA&gt;    guitar</code></pre>
+</div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb12"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># full_join: everyone is kept; gaps filled with NA</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="fu">full_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="cell-output cell-output-stdout">
+<pre><code># A tibble: 4 x 3
+  name  band    plays 
+  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; 
+1 Mick  Stones  &lt;NA&gt;  
+2 John  Beatles guitar
+3 Paul  Beatles bass  
+4 Keith &lt;NA&gt;    guitar</code></pre>
+</div>
+</div>
+</section>
+<section id="joining-on-columns-with-different-names" class="level2" data-number="13.3">
+<h2 data-number="13.3" class="anchored" data-anchor-id="joining-on-columns-with-different-names"><span class="header-section-number">13.3</span> Joining on columns with different names</h2>
+<p>If the key column has a different name in each table, use <code>join_by()</code> to specify which columns match:</p>
+<div class="cell">
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb14"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="co"># key is called "name" on the left and "artist" on the right</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="fu">left_join</span>(band_members, band_instruments2, <span class="at">by =</span> <span class="fu">join_by</span>(name <span class="sc">==</span> artist))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</div>
 <div class="callout callout-style-default callout-tip callout-titled">
 <div class="callout-header d-flex align-content-center">
 <div class="callout-icon-container">
@@ -409,19 +525,10 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </div>
 </div>
 <div class="callout-body-container callout-body">
-<p>joining_function(left data set, right data set, by = “column name”)</p>
-<p>joining_function(left data set, right data set, by = c(left column name= right column name))</p>
+<p>joining_function(left_table, right_table, by = “shared_column_name”)</p>
+<p># or, if the key columns have different names:</p>
+<p>joining_function(left_table, right_table, by = join_by(left_col == right_col))</p>
 </div>
-</div>
-<p>Here you can see an example of how to join to data sets:</p>
-<div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">inner_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">left_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="fu">right_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span>
-<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="fu">full_join</span>(band_members, band_instruments, <span class="at">by =</span> <span class="st">"name"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 
 

--- a/_book/practice_questions.html
+++ b/_book/practice_questions.html
@@ -406,8 +406,8 @@ Note
 <li></li>
 </ol>
 What are the steps to follow every time you start a new quatro doc?
-<div id="radio_QFEOGBDBYJ" class="webex-radiogroup">
-<label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value="answer"> <span>A</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>B</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>C</span></label><label><input type="radio" autocomplete="off" name="radio_QFEOGBDBYJ" value=""> <span>D</span></label>
+<div id="radio_NOZGQBCQOY" class="webex-radiogroup">
+<label><input type="radio" autocomplete="off" name="radio_NOZGQBCQOY" value="answer"> <span>A</span></label><label><input type="radio" autocomplete="off" name="radio_NOZGQBCQOY" value=""> <span>B</span></label><label><input type="radio" autocomplete="off" name="radio_NOZGQBCQOY" value=""> <span>C</span></label><label><input type="radio" autocomplete="off" name="radio_NOZGQBCQOY" value=""> <span>D</span></label>
 </div>
 <ol type="A">
 <li><p>Open Quarto and create a new document. Load in the necessary libraries. Load the dataset. Make sure progress is saved to OneDrive or on your computer.</p></li>
@@ -421,8 +421,8 @@ What are the steps to follow every time you start a new quatro doc?
 <div class="webex-check webex-box">
 <p>filter can be used to group rows: <select class="webex-select"><option value="blank"></option><option value="answer">TRUE</option><option value="">FALSE</option></select></p>
 Which is the correct form?
-<div id="radio_DGCPVOJOBB" class="webex-radiogroup">
-<label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value=""> <span>filter(species_id = 'GM')</span></label><label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value="answer"> <span>filter(species_id %in% c(DM, NL)</span></label><label><input type="radio" autocomplete="off" name="radio_DGCPVOJOBB" value=""> <span>filter(species_id == %in% c(DM, NL)</span></label>
+<div id="radio_COTTYEKFAL" class="webex-radiogroup">
+<label><input type="radio" autocomplete="off" name="radio_COTTYEKFAL" value=""> <span>filter(species_id = 'GM')</span></label><label><input type="radio" autocomplete="off" name="radio_COTTYEKFAL" value="answer"> <span>filter(species_id %in% c(DM, NL)</span></label><label><input type="radio" autocomplete="off" name="radio_COTTYEKFAL" value=""> <span>filter(species_id == %in% c(DM, NL)</span></label>
 </div>
 </div>
 <ol start="2" type="1">

--- a/_book/search.json
+++ b/_book/search.json
@@ -532,7 +532,40 @@
     "href": "joining_functions_extended.html",
     "title": "13  Joining functions",
     "section": "",
-    "text": "The joining functions allow you to merge separate data sets based on matching keys.\n\nleft_join() - Keeps all the values from the left table and matching rows from the right table. All unmatched rows in the right table will be NA.\nright_join() - Keeps all the values from the right table and matching rows from the left table. All unmatched rows in the left table will be NA.\ninner_join() - Keeps all values that have matching keys in both tables.\nfull_join() - Keeps all values from both tables and all unmatched rows will be NA.\n\n\n13.0.1 Useful functions and parameters\n\n\nby - Specifies the key column/s to join on.\nc() - Allows you to combine different joining keys if they don’t have the same name.\n\n\n\n\n\n\n\n\nTipYou do this by writing:\n\n\n\njoining_function(left data set, right data set, by = “column name”)\njoining_function(left data set, right data set, by = c(left column name= right column name))\n\n\nHere you can see an example of how to join to data sets:\n\ninner_join(band_members, band_instruments, by = \"name\")\n\nleft_join(band_members, band_instruments, by = \"name\")\n\nright_join(band_members, band_instruments, by = \"name\")\n\nfull_join(band_members, band_instruments, by = \"name\")",
+    "text": "13.1 The four join types\nThe joining functions allow you to merge separate data sets based on a shared key column — a column that appears in both tables and contains matching values, such as a species ID or a sample name.\nRows with no match in the other table get NA in the columns that came from that table.",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>13</span>  <span class='chapter-title'>Joining functions</span>"
+    ]
+  },
+  {
+    "objectID": "joining_functions_extended.html#the-four-join-types",
+    "href": "joining_functions_extended.html#the-four-join-types",
+    "title": "13  Joining functions",
+    "section": "",
+    "text": "Function\nRows kept\nUse when…\n\n\n\n\nleft_join()\nAll rows from the left table; matching rows from the right\nYou want to keep all your primary data and add extra columns where available\n\n\nright_join()\nAll rows from the right table; matching rows from the left\nSame idea, but your primary data is on the right\n\n\ninner_join()\nOnly rows with a matching key in both tables\nYou only want rows that exist in both data sets\n\n\nfull_join()\nAll rows from both tables\nYou want to keep everything and fill gaps with NA",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>13</span>  <span class='chapter-title'>Joining functions</span>"
+    ]
+  },
+  {
+    "objectID": "joining_functions_extended.html#seeing-joins-in-action",
+    "href": "joining_functions_extended.html#seeing-joins-in-action",
+    "title": "13  Joining functions",
+    "section": "13.2 Seeing joins in action",
+    "text": "13.2 Seeing joins in action\nThe examples below use two small built-in dplyr data sets. Here is what they contain:\n\n\n-- Attaching core tidyverse packages ------------------------ tidyverse 2.0.0 --\nv dplyr     1.2.1     v readr     2.2.0\nv forcats   1.0.1     v stringr   1.6.0\nv ggplot2   4.0.3     v tibble    3.3.1\nv lubridate 1.9.5     v tidyr     1.3.2\nv purrr     1.2.2     \n-- Conflicts ------------------------------------------ tidyverse_conflicts() --\nx dplyr::filter() masks stats::filter()\nx dplyr::lag()    masks stats::lag()\ni Use the conflicted package (&lt;http://conflicted.r-lib.org/&gt;) to force all conflicts to become errors\n\n\n\nband_members      # name + band\n\n# A tibble: 3 x 2\n  name  band   \n  &lt;chr&gt; &lt;chr&gt;  \n1 Mick  Stones \n2 John  Beatles\n3 Paul  Beatles\n\nband_instruments  # name + plays\n\n# A tibble: 3 x 2\n  name  plays \n  &lt;chr&gt; &lt;chr&gt; \n1 John  guitar\n2 Paul  bass  \n3 Keith guitar\n\n\nMick is in band_members but not in band_instruments. Keith is in band_instruments but not in band_members. The key column is name.\n\n# inner_join: only Mick and John appear in both tables — only they are kept\ninner_join(band_members, band_instruments, by = \"name\")\n\n# A tibble: 2 x 3\n  name  band    plays \n  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; \n1 John  Beatles guitar\n2 Paul  Beatles bass  \n\n# left_join: all of band_members is kept; Keith (right only) is dropped\nleft_join(band_members, band_instruments, by = \"name\")\n\n# A tibble: 3 x 3\n  name  band    plays \n  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; \n1 Mick  Stones  &lt;NA&gt;  \n2 John  Beatles guitar\n3 Paul  Beatles bass  \n\n# right_join: all of band_instruments is kept; Mick (left only) is dropped\nright_join(band_members, band_instruments, by = \"name\")\n\n# A tibble: 3 x 3\n  name  band    plays \n  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; \n1 John  Beatles guitar\n2 Paul  Beatles bass  \n3 Keith &lt;NA&gt;    guitar\n\n# full_join: everyone is kept; gaps filled with NA\nfull_join(band_members, band_instruments, by = \"name\")\n\n# A tibble: 4 x 3\n  name  band    plays \n  &lt;chr&gt; &lt;chr&gt;   &lt;chr&gt; \n1 Mick  Stones  &lt;NA&gt;  \n2 John  Beatles guitar\n3 Paul  Beatles bass  \n4 Keith &lt;NA&gt;    guitar",
+    "crumbs": [
+      "Part 3: R fundamentals",
+      "<span class='chapter-number'>13</span>  <span class='chapter-title'>Joining functions</span>"
+    ]
+  },
+  {
+    "objectID": "joining_functions_extended.html#joining-on-columns-with-different-names",
+    "href": "joining_functions_extended.html#joining-on-columns-with-different-names",
+    "title": "13  Joining functions",
+    "section": "13.3 Joining on columns with different names",
+    "text": "13.3 Joining on columns with different names\nIf the key column has a different name in each table, use join_by() to specify which columns match:\n\n# key is called \"name\" on the left and \"artist\" on the right\nleft_join(band_members, band_instruments2, by = join_by(name == artist))\n\n\n\n\n\n\n\nTipYou do this by writing:\n\n\n\njoining_function(left_table, right_table, by = “shared_column_name”)\n# or, if the key columns have different names:\njoining_function(left_table, right_table, by = join_by(left_col == right_col))",
     "crumbs": [
       "Part 3: R fundamentals",
       "<span class='chapter-number'>13</span>  <span class='chapter-title'>Joining functions</span>"

--- a/joining_functions_extended.qmd
+++ b/joining_functions_extended.qmd
@@ -1,35 +1,64 @@
 # Joining functions
 
-The joining functions allow you to merge separate data sets based on matching keys.
+The joining functions allow you to merge separate data sets based on a shared **key** column — a column that appears in both tables and contains matching values, such as a species ID or a sample name.
 
--   `left_join()` - Keeps all the values from the left table and matching rows from the right table. All unmatched rows in the right table will be NA.
--   `right_join()` - Keeps all the values from the right table and matching rows from the left table. All unmatched rows in the left table will be NA.
--   `inner_join()` - Keeps all values that have matching keys in both tables.
--   `full_join()` - Keeps all values from both tables and all unmatched rows will be NA.
+## The four join types
 
-### Useful functions and parameters
+| Function | Rows kept | Use when… |
+|---|---|---|
+| `left_join()` | All rows from the **left** table; matching rows from the right | You want to keep all your primary data and add extra columns where available |
+| `right_join()` | All rows from the **right** table; matching rows from the left | Same idea, but your primary data is on the right |
+| `inner_join()` | Only rows with a matching key **in both** tables | You only want rows that exist in both data sets |
+| `full_join()` | All rows from **both** tables | You want to keep everything and fill gaps with `NA` |
 
-> -   `by` - Specifies the key column/s to join on.
-> -   `c()` - Allows you to combine different joining keys if they don't have the same name.
+Rows with no match in the other table get `NA` in the columns that came from that table.
+
+## Seeing joins in action
+
+The examples below use two small built-in dplyr data sets. Here is what they contain:
+
+```{r}
+#| echo: false
+library(tidyverse)
+```
+
+```{r}
+band_members      # name + band
+band_instruments  # name + plays
+```
+
+`Mick` is in `band_members` but not in `band_instruments`. `Keith` is in `band_instruments` but not in `band_members`. The key column is `name`.
+
+```{r}
+# inner_join: only Mick and John appear in both tables — only they are kept
+inner_join(band_members, band_instruments, by = "name")
+
+# left_join: all of band_members is kept; Keith (right only) is dropped
+left_join(band_members, band_instruments, by = "name")
+
+# right_join: all of band_instruments is kept; Mick (left only) is dropped
+right_join(band_members, band_instruments, by = "name")
+
+# full_join: everyone is kept; gaps filled with NA
+full_join(band_members, band_instruments, by = "name")
+```
+
+## Joining on columns with different names
+
+If the key column has a different name in each table, use `join_by()` to specify which columns match:
+
+```{r}
+#| eval: false
+# key is called "name" on the left and "artist" on the right
+left_join(band_members, band_instruments2, by = join_by(name == artist))
+```
 
 ::: callout-tip
 ## You do this by writing:
 
-joining_function(left data set, right data set, by = "column name")
+joining_function(left_table, right_table, by = "shared_column_name")
 
-joining_function(left data set, right data set, by = c(left column name= right column name))
+\# or, if the key columns have different names:
+
+joining_function(left_table, right_table, by = join_by(left_col == right_col))
 :::
-
-Here you can see an example of how to join to data sets:
-
-```{r}
-#| eval: false
-inner_join(band_members, band_instruments, by = "name")
-
-left_join(band_members, band_instruments, by = "name")
-
-right_join(band_members, band_instruments, by = "name")
-
-full_join(band_members, band_instruments, by = "name")
-
-```


### PR DESCRIPTION
- Add table comparing all four join types with when-to-use guidance
- Show band_members/band_instruments data before joining so students can follow which rows appear in each result
- Run joins with live output rather than eval:false so results are visible
- Add join_by() example for columns with different names Closes #39, #55.